### PR TITLE
fix: Replace typing.BinaryIO with io.IOBase in type check

### DIFF
--- a/sprc/header.py
+++ b/sprc/header.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Final, BinaryIO, Self
-
+import io
 from fastcrc import crc16
 
 # Magic bytes that identify SPRC files
@@ -101,7 +101,7 @@ class SprcHeader:
         Returns:
             True if the calculated CRC matches the stored CRC, False otherwise
         """
-        if isinstance(data, BinaryIO):
+        if isinstance(data, io.IOBase):
             # Save current position
             position = data.tell()
 


### PR DESCRIPTION
# TL;DR
This PR fixes a run-time error when converting OKD to SMF.

# Details of the error encountered
The error occur when converting SPRC format OKDs from DAM-XG5000 to SMF.

This is the log(Paths and file names are removed):
```
[Deleted]\python.exe [Deleted]\dam-song-tools-oss\dam_song_tools_cli\cli.py okd_to_midi -s False .\[Deleted] [Deleted].mid 
[2025-07-12 20:40:43,684] INFO [okd.okd_file.read:501] SPRC Header detected.
Traceback (most recent call last):
  File "[Deleted]\dam-song-tools-oss\dam_song_tools_cli\cli.py", line 304, in <module>
    main()
    ~~~~^^
  File "[Deleted]\dam-song-tools-oss\dam_song_tools_cli\cli.py", line 300, in main
    fire.Fire(Cli)
    ~~~~~~~~~^^^^^
  File "[Deleted]\Lib\site-packages\fire\core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "[Deleted]\Lib\site-packages\fire\core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ~~~~~~~~~~~~~~~~~~~^
        component,
        ^^^^^^^^^^
    ...<2 lines>...
        treatment='class' if is_class else 'routine',
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        target=component.__name__)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[Deleted]\Lib\site-packages\fire\core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "[Deleted]\dam-song-tools-oss\dam_song_tools_cli\cli.py", line 235, in okd_to_midi
    okd = OkdFile.read(okd_file)
  File "[Deleted]\dam-song-tools-oss\okd\okd_file.py", line 503, in read
    if not sprc_header.validate_crc(stream):
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "[Deleted]\dam-song-tools-oss\sprc\header.py", line 120, in validate_crc
    calculated_crc = crc16.genibus(data_bytes)
  File "[Deleted]\Lib\site-packages\fastcrc\crc16.py", line 252, in genibus
    return _crc_16_genibus(data, initial)
TypeError: argument 'data': 'BufferedReader' object cannot be converted to 'PyBytes'
```

The object `open(..., "rb")` returned is not recognised by the runtime as an instance of `typing.BinaryIO`, resulting in returning `False` in `isinstance()`.
As a result, the object is not correctly converted into `bytes` and an error is  occured during the calculation of the CRC.

# How fixed?

I changed the target of `isinstance()` to `io.IOBase`



